### PR TITLE
feat: don't quote colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1809,6 +1809,11 @@
       "dev": true,
       "optional": true
     },
+    "css-color-names": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-1.0.1.tgz",
+      "integrity": "sha512-/loXYOch1qU1biStIFsHH8SxTmOseh1IJqFvy8IujXOm1h+QjUdDhkzOrR5HG8K8mlxREj0yfi8ewCHx0eMxzA=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "url": "https://github.com/gkatsev/rootbeer"
   },
   "dependencies": {
+    "css-color-names": "^1.0.1",
     "lodash.isplainobject": "^4.0.6",
     "minimist": "^1.2.5",
     "object.assign": "^4.1.2",

--- a/src/is-color.js
+++ b/src/is-color.js
@@ -1,0 +1,3 @@
+export default function(value) {
+  return false
+}

--- a/src/is-color.js
+++ b/src/is-color.js
@@ -1,3 +1,7 @@
+import csscolors from 'css-color-names';
+
+const names = Object.keys(csscolors);
+
 export default function(value) {
-  return (/^(?:#|rgba?|hsla?)/).test(value);
+  return (/^(?:#|rgba?|hsla?)/).test(value) || names.includes(value);
 }

--- a/src/is-color.js
+++ b/src/is-color.js
@@ -1,3 +1,3 @@
 export default function(value) {
-  return false
+  return (/^(?:#|rgba?|hsla?)/).test(value);
 }

--- a/src/jsToSassString.js
+++ b/src/jsToSassString.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import isPlainObject from 'lodash.isplainobject';
+import isColor from './is-color.js';
 let { isArray } = Array;
 
 function jsToSassString(value) {
@@ -13,7 +14,7 @@ function jsToSassString(value) {
       case 'number':
         return value.toString();
       case 'string':
-        return `"${strEsc(value)}"`;
+        return quoteString(strEsc(value));
       case 'object':
         if (isPlainObject(value)) {
           indentLevel += 1;
@@ -54,6 +55,14 @@ function jsToSassString(value) {
   }
 
   return _jsToSassString(value);
+}
+
+function quoteString(value) {
+  if (isColor(value)) {
+    return value;
+  }
+
+  return `"${value}"`;
 }
 
 function indentsToSpaces(indentCount) {

--- a/src/tests/jsToSassString-test.js
+++ b/src/tests/jsToSassString-test.js
@@ -18,6 +18,10 @@ describe('JS to Sass', function() {
 
   // https://sass-lang.com/documentation/values/colors
   it('should handle colors', function() {
+    expect(jsToSassString('papayawhip')).to.equal('papayawhip');
+    expect(jsToSassString('lightgoldenrodyellow')).to.equal('lightgoldenrodyellow');
+    expect(jsToSassString('gray')).to.equal('gray');
+    expect(jsToSassString('grey')).to.equal('grey');
     expect(jsToSassString('#f2ece4')).to.equal('#f2ece4');
     expect(jsToSassString('#b37399aa')).to.equal('#b37399aa');
     expect(jsToSassString('rgb(204, 102, 153)')).to.equal('rgb(204, 102, 153)');

--- a/src/tests/jsToSassString-test.js
+++ b/src/tests/jsToSassString-test.js
@@ -18,13 +18,12 @@ describe('JS to Sass', function() {
 
   // https://sass-lang.com/documentation/values/colors
   it('should handle colors', function() {
-    expect(jsToSassString('foo')).to.equal('"foo"');
-    expect(jsToSassString('#f2ece4')).to.equal('"#f2ece4"');
-    expect(jsToSassString('#b37399aa')).to.equal('"#b37399aa"');
-    expect(jsToSassString('rgb(204, 102, 153)')).to.equal('"rgb(204, 102, 153)"');
-    expect(jsToSassString('rgba(107, 133, 127, 0.8)')).to.equal('"rgba(107, 133, 127, 0.8)"');
-    expect(jsToSassString('hsl(228, 7%, 86%)')).to.equal('"hsl(228, 7%, 86%)"');
-    expect(jsToSassString('hsla(20, 20%, 85%, 0.7)')).to.equal('"hsla(20, 20%, 85%, 0.7)"');
+    expect(jsToSassString('#f2ece4')).to.equal('#f2ece4');
+    expect(jsToSassString('#b37399aa')).to.equal('#b37399aa');
+    expect(jsToSassString('rgb(204, 102, 153)')).to.equal('rgb(204, 102, 153)');
+    expect(jsToSassString('rgba(107, 133, 127, 0.8)')).to.equal('rgba(107, 133, 127, 0.8)');
+    expect(jsToSassString('hsl(228, 7%, 86%)')).to.equal('hsl(228, 7%, 86%)');
+    expect(jsToSassString('hsla(20, 20%, 85%, 0.7)')).to.equal('hsla(20, 20%, 85%, 0.7)');
   });
 
   it('should handle booleans', function() {

--- a/src/tests/jsToSassString-test.js
+++ b/src/tests/jsToSassString-test.js
@@ -16,6 +16,17 @@ describe('JS to Sass', function() {
     expect(jsToSassString('foo')).to.equal('"foo"');
   });
 
+  // https://sass-lang.com/documentation/values/colors
+  it('should handle colors', function() {
+    expect(jsToSassString('foo')).to.equal('"foo"');
+    expect(jsToSassString('#f2ece4')).to.equal('"#f2ece4"');
+    expect(jsToSassString('#b37399aa')).to.equal('"#b37399aa"');
+    expect(jsToSassString('rgb(204, 102, 153)')).to.equal('"rgb(204, 102, 153)"');
+    expect(jsToSassString('rgba(107, 133, 127, 0.8)')).to.equal('"rgba(107, 133, 127, 0.8)"');
+    expect(jsToSassString('hsl(228, 7%, 86%)')).to.equal('"hsl(228, 7%, 86%)"');
+    expect(jsToSassString('hsla(20, 20%, 85%, 0.7)')).to.equal('"hsla(20, 20%, 85%, 0.7)"');
+  });
+
   it('should handle booleans', function() {
     expect(jsToSassString(true)).to.equal('true');
     expect(jsToSassString(false)).to.equal('false');


### PR DESCRIPTION
Taking a play from https://github.com/acdlite/json-sass/pull/14, this change makes it so that string values that contain colors do not get quotes. Specifically, this includes hex colors, rgb, rgba, hsl, hsla, and css color names.

Fixes #4

BREAKING CHANGE: colors will no longer be quotes with this release.